### PR TITLE
Improvement to repeating task functionality

### DIFF
--- a/src/main/java/seedu/todolist/logic/command/AddTaskCommand.java
+++ b/src/main/java/seedu/todolist/logic/command/AddTaskCommand.java
@@ -40,7 +40,11 @@ public class AddTaskCommand extends Command {
         try {
             repeatDuration = Integer.parseInt(args.get(Flags.REPEAT.FLAG));
         } catch (NumberFormatException e) {
-            throw new InvalidDurationException();
+            if (args.get(Flags.REPEAT.FLAG) == null) {
+                repeatDuration = 0;
+            } else {
+                throw new InvalidDurationException();
+            }
         }
     }
 

--- a/src/main/java/seedu/todolist/logic/command/CheckRepeatingTaskCommand.java
+++ b/src/main/java/seedu/todolist/logic/command/CheckRepeatingTaskCommand.java
@@ -7,8 +7,6 @@ import seedu.todolist.task.TaskList;
 public class CheckRepeatingTaskCommand extends Command {
     public static final String KEYWORD = "check";
 
-    private int index;
-
     public CheckRepeatingTaskCommand() {}
 
     @Override


### PR DESCRIPTION
Remove unused index variable in CheckRepeatingTaskCommand
Allow users to leave repeat frequency blank when adding task - will assume that repeat frequency = 0 if not given. else if non-integer is provided, InvalidDurationException will be thrown